### PR TITLE
Lint with Ruff CI pipeline.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint with Ruff
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+        
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        default: true
+
+    - name: Clone Ruff
+      run: git clone https://github.com/charliermarsh/ruff.git
+
+    - name: Build Ruff
+      run: cd ruff && cargo build --release
+
+    - name: Lint with Ruff
+      run: ./ruff/target/release/ruff ./deltatorch/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,28 +7,22 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-        
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
 
-    - name: Clone Ruff
-      run: git clone https://github.com/charliermarsh/ruff.git
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
 
-    - name: Build Ruff
-      run: cd ruff && cargo build --release
+      - name: Lint with Ruff
+        run: ruff ./deltatorch/
 
-    - name: Lint with Ruff
-      run: ./ruff/target/release/ruff ./deltatorch/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![![image](https://github.com/mshtelma/deltatorch/workflows/build/badge.svg)](https://github.com/mshtelma/deltatorch/actions/workflows/ci.yml/badge.svg)
 ![![image](https://github.com/mshtelma/deltatorch/workflows/build/badge.svg)](https://github.com/mshtelma/deltatorch/actions/workflows/flake8.yml/badge.svg)
+![![image](https://github.com/mshtelma/deltatorch/workflows/build/badge.svg)](https://github.com/mshtelma/deltatorch/actions/workflows/black.yml/badge.svg)
 
 ## Concept
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![![image](https://github.com/mshtelma/deltatorch/workflows/build/badge.svg)](https://github.com/mshtelma/deltatorch/actions/workflows/ci.yml/badge.svg)
 ![![image](https://github.com/mshtelma/deltatorch/workflows/build/badge.svg)](https://github.com/mshtelma/deltatorch/actions/workflows/flake8.yml/badge.svg)
 ![![image](https://github.com/mshtelma/deltatorch/workflows/build/badge.svg)](https://github.com/mshtelma/deltatorch/actions/workflows/black.yml/badge.svg)
+![![image](https://github.com/mshtelma/deltatorch/workflows/build/badge.svg)](https://github.com/mshtelma/deltatorch/actions/workflows/lint.yml/badge.svg)
 
 ## Concept
 


### PR DESCRIPTION
Closes #3 

Adding the lint with Ruff CI pipelline and also updated the readme with the badge for the pipeline run status.

The Ruff lint pipeline currently fails the pipeline when linting check doesn't passes as seen below.
<img width="703" alt="image" src="https://github.com/delta-incubator/deltatorch/assets/98817232/23551fd9-6da9-4f96-ac52-8f22165679e3">

but if required @MrPowers I can add a `--fix` option to the pipeline for automatic fixing. Let me know if that needs to be added.